### PR TITLE
Revert "Add release date for Laravel 6"

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
         },
         {
             version: '6.0',
-            releaseDate: moment('2019-09-03'),
+            releaseDate: null,
             isLTS: true,
             php: '7.2.0'
         }


### PR DESCRIPTION
Reverts Jamesking56/WhichLaravel.me#21

Reverting because it shows up as 'Released' on the site.